### PR TITLE
Fix issue with activePage option

### DIFF
--- a/paging.js
+++ b/paging.js
@@ -13,7 +13,8 @@
                 this.options.rowDisplayStyle = rows.css('display');
                 var nav = this._getNavBar();
                 this.element.after(nav);
-                this.showPage(0);
+                $(".paging-nav a[data-page='"+ this.options.activePage +"']").addClass('selected-page');
+                this.showPage(this.options.activePage);
             },
             _getNavBar: function() {
                 var rows = this.options.rows;
@@ -57,8 +58,8 @@
             },
             pageClickHandler: function(event) {
                 event.preventDefault();
-                $(event.target).siblings().attr('class', "");
-                $(event.target).attr('class', "selected-page");
+                $(event.target).siblings().removeClass('selected-page');
+                $(event.target).addClass("selected-page");
                 var pageNum = $(event.target).attr('data-page');
                 this.showPage(pageNum);
             },
@@ -75,6 +76,3 @@
         });
     });
 })(jQuery);
-
-
-


### PR DESCRIPTION
This commit resolves the following issues:

1. Active page is not highlighted [open issue](https://github.com/mz0lee/paging/issues/3)
2. Instead of replacing the element classes using `attr()` function, `addClass()` and `removeClass()` function are used. These will only add / remove the mentioned class and not replace the whole class attribute of HTML element. 